### PR TITLE
Replace raw2zarr with new repository

### DIFF
--- a/blog/2024-10-untapped-promise-radar-data.md
+++ b/blog/2024-10-untapped-promise-radar-data.md
@@ -73,7 +73,7 @@ This isn't just a dream - the technology exists today.
 
 ## Making It Reality
 
-Through projects like `raw2zarr` and the Open Radar Science community, we're working to:
+Through projects like `radar-datatree` and the Open Radar Science community, we're working to:
 
 - Convert historical archives to cloud-optimized formats
 - Develop standardized processing workflows
@@ -97,4 +97,4 @@ The promise is enormous. The time to act is now.
 
 ---
 
-*Interested in contributing to open radar science? Check out the [Open Radar Science community](https://openradarscience.org/) or explore [raw2zarr](https://github.com/aladinor/raw2zarr) for cloud-optimized radar data workflows.*
+*Interested in contributing to open radar science? Check out the [Open Radar Science community](https://openradarscience.org/) or explore [radar-datatree](https://github.com/aladinor/radar-datatree) for cloud-optimized radar data workflows.*

--- a/blog/2024-12-radar-scan-datasets.md
+++ b/blog/2024-12-radar-scan-datasets.md
@@ -36,7 +36,7 @@ By converting radar data to Zarr format with careful attention to chunk sizing a
 
 ## Key Design Principles
 
-The approach I've developed through `raw2zarr` focuses on:
+The approach I've developed through `radar-datatree` focuses on:
 
 - **Preserving metadata**: Maintaining all original radar metadata and quality flags
 - **Optimal chunking**: Balancing between query performance and storage efficiency
@@ -47,6 +47,6 @@ The approach I've developed through `raw2zarr` focuses on:
 
 ## Tools and Resources
 
-- [raw2zarr](https://github.com/aladinor/raw2zarr) - Python package for converting radar data to Zarr
+- [radar-datatree](https://github.com/aladinor/radar-datatree) - Python package for converting radar data to Zarr
 - [xradar](https://github.com/openradar/xradar) - Radar data toolkit for Python
 - Example notebooks demonstrating cloud-native radar workflows

--- a/cv.md
+++ b/cv.md
@@ -45,6 +45,6 @@ PhD candidate in atmospheric sciences specializing in:
 
 **Data Formats:** Zarr, NetCDF, HDF5, GRIB, Parquet | ARCO principles
 
-**Software Projects:** raw2zarr (Lead Developer) | xarray and xradar (Contributor) | Open Radar, Project Pythia (Member)
+**Software Projects:** radar-datatree (Lead Developer) | xarray and xradar (Contributor) | Open Radar, Project Pythia (Member)
 
 For complete details including publications and talks, please download the full CV above.

--- a/index.md
+++ b/index.md
@@ -40,7 +40,7 @@ site:
 
 ::::
 
-I work extensively with [raw2zarr](https://github.com/aladinor/raw2zarr) for cloud-optimized radar data, contribute to [xradar](https://github.com/openradar/xradar) and the [Open Radar Science](https://openradarscience.org/) community, and develop tools for GPM validation networks.
+I work extensively with [radar-datatree](https://github.com/aladinor/radar-datatree) for cloud-optimized radar data, contribute to [xradar](https://github.com/openradar/xradar) and the [Open Radar Science](https://openradarscience.org/) community, and develop tools for GPM validation networks.
 
 ## Quick Links
 

--- a/projects.md
+++ b/projects.md
@@ -4,10 +4,10 @@ Here are some of the key research projects and open-source contributions I've be
 
 ## Research Projects
 
-### raw2zarr: Cloud-Optimized Weather Radar Data
+### radar-datatree: Cloud-Optimized Weather Radar Data
 
 ```{card}
-:link: https://github.com/aladinor/raw2zarr
+:link: https://github.com/aladinor/radar-datatree
 
 **Converting weather radar data to cloud-optimized Zarr format**
 

--- a/publications.md
+++ b/publications.md
@@ -22,10 +22,10 @@ For a complete list of publications, visit my [ORCID profile](https://orcid.org/
 
 ## Open Source Software
 
-### Raw2zarr
+### radar-datatree
 A Python package for converting weather radar data to cloud-optimized Zarr format, enabling efficient analysis of large radar datasets.
 
-**Repository**: [https://github.com/aladinor/raw2zarr](https://github.com/aladinor/raw2zarr)
+**Repository**: [https://github.com/aladinor/radar-datatree](https://github.com/aladinor/radar-datatree)
 
 ### Xradar Contributions
 Contributions to the Xradar ecosystem for processing and analyzing weather radar data.


### PR DESCRIPTION
Update all references from the private raw2zarr repository to the new public radar-datatree repository at github.com/aladinor/radar-datatree.